### PR TITLE
Mayhem integration for jpeg-decoder

### DIFF
--- a/.github/workflows/mayhem.yaml
+++ b/.github/workflows/mayhem.yaml
@@ -1,0 +1,69 @@
+name: Mayhem
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  PROJECTNAME: jpeg-decoder
+  FAIL_TMIN_MAYHEMFILE: Mayhem/fail_tmin.mayhemfile
+  REGRESSION_MAYHEMFILE: Mayhem/regression.mayhemfile
+
+jobs:
+  build:
+    name: '${{ matrix.os }} shared=${{ matrix.shared }} ${{ matrix.build_type }}'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        shared: [false]
+        build_type: [Release]
+        include:
+          - os: ubuntu-latest
+            triplet: x64-linux
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          file: Dockerfile.mayhem
+
+      - name: Start analysis for fail_tmin
+        uses: ForAllSecure/mcode-action@v1
+        with:
+          mayhem-token: ${{ secrets.MAYHEM_TOKEN }}
+          args: --image ${{ steps.meta.outputs.tags }} --project ${{ env.PROJECTNAME }} --file ${{ env.FAIL_TMIN_MAYHEMFILE }}
+          sarif-output: sarif
+
+      - name: Start analysis for regression
+        uses: ForAllSecure/mcode-action@v1
+        with:
+          mayhem-token: ${{ secrets.MAYHEM_TOKEN }}
+          args: --image ${{ steps.meta.outputs.tags }} --project ${{ env.PROJECTNAME }} --file ${{ env.REGRESSION_MAYHEMFILE }}
+          sarif-output: sarif
+
+      - name: Upload SARIF file(s)
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: sarif

--- a/Dockerfile.mayhem
+++ b/Dockerfile.mayhem
@@ -1,0 +1,20 @@
+# Use Rust to build
+FROM rustlang/rust:nightly as builder
+
+# Add source code to the build stage.
+ADD . /jpeg-decoder
+WORKDIR /jpeg-decoder
+
+RUN cargo install cargo-fuzz
+
+# BUILD INSTRUCTIONS
+WORKDIR /jpeg-decoder/fuzz
+RUN cargo +nightly fuzz build fail_tmin && \
+    cargo +nightly fuzz build regression
+# Output binaries are placed in /jpeg-decoder/fuzz/target/x86_64-unknown-linux-gnu/release/
+
+# Package Stage -- we package for a plain Ubuntu machine
+FROM --platform=linux/amd64 ubuntu:20.04
+
+# Copy the binary from the build stage to an Ubuntu docker image
+COPY --from=builder /jpeg-decoder/fuzz/target/x86_64-unknown-linux-gnu/release/fail_tmin /jpeg-decoder/fuzz/target/x86_64-unknown-linux-gnu/release/regression /

--- a/Mayhem/fail_tmin.mayhemfile
+++ b/Mayhem/fail_tmin.mayhemfile
@@ -1,6 +1,5 @@
 project: jpeg-decoder
 target: fail_tmin
-image: ghcr.io/aaronjsteele/jpeg-decoder:latest
 
 cmds:
   - cmd: /fail_tmin

--- a/Mayhem/fail_tmin.mayhemfile
+++ b/Mayhem/fail_tmin.mayhemfile
@@ -1,0 +1,6 @@
+project: jpeg-decoder
+target: fail_tmin
+image: ghcr.io/aaronjsteele/jpeg-decoder:latest
+
+cmds:
+  - cmd: /fail_tmin

--- a/Mayhem/regression.mayhemfile
+++ b/Mayhem/regression.mayhemfile
@@ -1,0 +1,6 @@
+project: jpeg-decoder
+target: regression
+image: ghcr.io/aaronjsteele/jpeg-decoder:latest
+
+cmds:
+  - cmd: /regression

--- a/Mayhem/regression.mayhemfile
+++ b/Mayhem/regression.mayhemfile
@@ -1,6 +1,5 @@
 project: jpeg-decoder
 target: regression
-image: ghcr.io/aaronjsteele/jpeg-decoder:latest
 
 cmds:
   - cmd: /regression


### PR DESCRIPTION
Adds Mayhem integration with GitHub actions for the `jpeg-decoder` project. This includes a `Dockerfile`, multiple `Mayhemfiles`, and a GitHub action to automatically run the Mayhem fuzzing.

Multiple fuzzing tests were provided in this project, and a Mayhemfile has been provided for each. Similarly, the GitHub action accounts for running the fuzzing targets in sequence.